### PR TITLE
Add gh CLI usage note to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,3 +2,4 @@
 
 - Use `conda activate claude_usage` for the project virtualenv.
 - Don't add "Generated with Claude Code" lines to PRs.
+- When using `gh` CLI, always pass `--repo dlichtenberg/claude_usage_bar` since the local git remote is a proxy and not recognized as a GitHub host.


### PR DESCRIPTION
The local git remote uses a proxy, so gh doesn't recognize it as a
GitHub host. Document the --repo flag workaround.

https://claude.ai/code/session_01TUQ4QLn4wJLCXAQ6YcD56A