### PR TITLE
Add PyPI distribution support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dlichtenberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,28 @@ build-backend = "setuptools.build_meta"
 name = "claude-usage-bar"
 dynamic = ["version"]
 description = "macOS menu bar app showing Claude API usage limits"
+readme = "README.md"
+license = "MIT"
+authors = [{name = "dlichtenberg"}]
 requires-python = ">=3.10"
 dependencies = [
     "rumps>=0.4.0,<0.5",
     "pyobjc-framework-Cocoa>=10.0",
 ]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: MacOS X",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Utilities",
+]
+
+[project.urls]
+Homepage = "https://github.com/dlichtenberg/claude_usage_bar"
+Repository = "https://github.com/dlichtenberg/claude_usage_bar"
+"Bug Tracker" = "https://github.com/dlichtenberg/claude_usage_bar/issues"
 
 [project.scripts]
 claude-usage-bar = "claude_usage.app:main"


### PR DESCRIPTION
## Summary

- Add PyPI metadata (`readme`, `license`, `authors`, `classifiers`, `project.urls`) to `pyproject.toml`
- Add MIT license file
- Add GitHub Actions publish workflow using trusted publishing (OIDC, no API tokens)

## Post-merge setup

1. Register trusted publisher at https://pypi.org/manage/account/publishing/ (owner: `dlichtenberg`, repo: `claude_usage_bar`, workflow: `publish.yml`, environment: `pypi`)
2. Create GitHub environment `pypi` in repo Settings > Environments
3. To publish: bump `__version__`, commit, create a GitHub Release — workflow publishes automatically

Closes #5