### PR TITLE
Fix auth error state when Claude CLI not found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,14 @@
 - Use `conda activate claude_usage` for the project virtualenv.
 - Don't add "Generated with Claude Code" lines to PRs.
 - When using `gh` CLI, always pass `--repo dlichtenberg/claude_usage_bar` since the local git remote is a proxy and not recognized as a GitHub host.
+- Do not implement direct OAuth token refresh in this app. Token refresh should be handled by the Claude CLI, not by this app.
+
+## Debugging Auth Errors
+
+The app logs the auth/refresh flow via Python `logging` (INFO by default). Set `CLAUDE_USAGE_LOG=DEBUG` for verbose output. When running from Terminal, logs go to stderr. Key things to look for:
+
+- **"Claude CLI binary not found"** — `find_claude()` checked PATH and fallback paths (`~/.local/bin/claude`, `~/.claude/local/claude`, `/usr/local/bin/claude`, `/opt/homebrew/bin/claude`). None existed or were executable.
+- **"No access token found in keychain"** — the macOS Keychain has no entry for `Claude Code-credentials`. Run `claude` in Terminal to authenticate.
+- **"Token expired, attempting refresh"** — the API returned 401. The app will try `claude auth status` to trigger a token refresh.
+- **"Token refresh failed"** — `claude auth status` returned non-zero. Check the logged stderr output for details.
+- **"Cannot refresh: Claude CLI not found"** — refresh was needed but the binary couldn't be located (same as the first bullet).

--- a/src/claude_usage/core.py
+++ b/src/claude_usage/core.py
@@ -4,12 +4,15 @@ Pure stdlib — no rumps or PyObjC imports.
 """
 
 import json
+import logging
 import os
 import shutil
 import subprocess
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
 
 BASE_API_URL = "https://api.anthropic.com"
 KEYCHAIN_SERVICE = "Claude Code-credentials"
@@ -22,23 +25,28 @@ def get_access_token():
         capture_output=True, text=True, timeout=15,
     )
     if result.returncode != 0:
+        logger.debug("Keychain lookup failed (exit %d)", result.returncode)
         return None
 
     raw = result.stdout.strip()
     if not raw:
+        logger.debug("Keychain returned empty credentials")
         return None
 
     try:
         creds = json.loads(raw)
     except json.JSONDecodeError:
-        return raw if raw else None
+        logger.debug("Keychain value is not JSON, using as raw token")
+        return raw  # guaranteed non-empty by check above
 
     if not isinstance(creds, dict):
+        logger.debug("Keychain JSON is not a dict")
         return None
 
     # Top-level token
     for key in ("accessToken", "access_token"):
         if key in creds:
+            logger.debug("Found token under top-level key '%s'", key)
             return creds[key]
 
     # Nested under claudeAiOauth or similar
@@ -46,8 +54,10 @@ def get_access_token():
         if isinstance(obj, dict):
             for key in ("accessToken", "access_token"):
                 if key in obj:
+                    logger.debug("Found token under nested key '%s'", key)
                     return obj[key]
 
+    logger.warning("Keychain credentials present but no access token found")
     return None
 
 
@@ -64,42 +74,66 @@ def fetch_usage(token):
         with urllib.request.urlopen(req, timeout=10) as resp:
             body = resp.read().decode()
             data = json.loads(body)
+            logger.debug("Usage API call succeeded")
             return data, None
     except urllib.error.HTTPError as e:
         code = f"HTTP {e.code} {e.reason}"
-        return None, ("auth_expired" if e.code == 401 else code)
+        err = "auth_expired" if e.code == 401 else code
+        logger.warning("Usage API HTTP error: %s", code)
+        return None, err
     except urllib.error.URLError as e:
+        logger.warning("Usage API URL error: %s", e.reason)
         return None, f"URL error: {e.reason}"
     except json.JSONDecodeError:
+        logger.warning("Usage API returned invalid JSON")
         return None, "Invalid JSON response"
     except Exception as e:
+        logger.warning("Usage API unexpected error: %s", e)
         return None, f"{type(e).__name__}: {e}"
 
 
-def _find_claude():
+def find_claude():
     """Resolve the claude binary path, checking common locations."""
     found = shutil.which("claude")
     if found:
+        logger.debug("Found claude via PATH: %s", found)
         return found
     for path in [
-        os.path.expanduser("~/.claude/local/claude"),
-        "/usr/local/bin/claude",
+        os.path.expanduser("~/.local/bin/claude"),    # native installer
+        os.path.expanduser("~/.claude/local/claude"),  # legacy
+        "/usr/local/bin/claude",                       # Intel Homebrew / manual
+        "/opt/homebrew/bin/claude",                    # Apple Silicon Homebrew
     ]:
         if os.path.isfile(path) and os.access(path, os.X_OK):
+            logger.debug("Found claude at fallback path: %s", path)
             return path
+    logger.warning("Claude CLI binary not found in PATH or fallback locations")
     return None
 
 
 def trigger_claude_refresh():
     """Ask Claude Code to refresh its own tokens via `claude auth status`."""
-    claude_bin = _find_claude()
+    claude_bin = find_claude()
     if not claude_bin:
+        logger.warning("Cannot refresh: Claude CLI not found")
         return False
-    result = subprocess.run(
-        [claude_bin, "auth", "status"],
-        capture_output=True, timeout=15,
-    )
-    return result.returncode == 0
+    cmd = [claude_bin, "auth", "status"]
+    logger.debug("Running token refresh: %s", cmd)
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=15)
+    except subprocess.TimeoutExpired:
+        logger.warning("Token refresh timed out after 15s")
+        return False
+    if result.returncode != 0:
+        logger.warning("Token refresh failed (exit %d)", result.returncode)
+        logger.debug(
+            "Token refresh output: stdout=%s stderr=%s",
+            result.stdout[:200] if result.stdout else b"",
+            result.stderr[:200] if result.stderr else b"",
+        )
+        return False
+    logger.debug("Token refresh succeeded")
+    return True
 
 
 def time_until(iso_timestamp):


### PR DESCRIPTION
## Summary
- Add `~/.local/bin/claude` (native installer) and `/opt/homebrew/bin/claude` (Apple Silicon Homebrew) to `find_claude()` fallback paths, fixing the root cause where the CLI binary wasn't found when running as a menu bar app with minimal PATH
- Add structured logging throughout the auth/refresh flow (`get_access_token`, `fetch_usage`, `find_claude`, `trigger_claude_refresh`, `_fetch_bg`, `_apply_result`) with configurable log level via `CLAUDE_USAGE_LOG` env var (defaults to INFO)
- Show actionable error hints in the dropdown menu (e.g., "Run 'claude' in Terminal to authenticate", "Install Claude Code CLI", "Open Claude Code to refresh, or click Refresh")
- Handle `subprocess.TimeoutExpired` explicitly in `trigger_claude_refresh()`

Closes #8

## Test plan
- [ ] Run `conda activate claude_usage && python -m claude_usage` — app should launch and show usage
- [ ] Run with `CLAUDE_USAGE_LOG=DEBUG` to verify auth flow logs appear
- [ ] Verify `find_claude()` resolves to `~/.local/bin/claude`
- [ ] Simulate missing credentials (rename keychain entry) and verify "No keychain credentials" error with hint appears
- [ ] Verify no tokens or sensitive data appear in logs at INFO level