### PR TITLE
Handle null API fields to fix AttributeError on seven_day_sonnet

### DIFF
--- a/claude-usage.5m.py
+++ b/claude-usage.5m.py
@@ -336,10 +336,10 @@ def print_error(msg):
 def render(data):
     """Render the full SwiftBar output from API response data."""
     # Determine the "headline" percentage — use the highest utilization
-    five_hour = data.get("five_hour", {})
-    seven_day = data.get("seven_day", {})
-    seven_day_sonnet = data.get("seven_day_sonnet", {})
-    extra = data.get("extra_usage", {})
+    five_hour = data.get("five_hour") or {}
+    seven_day = data.get("seven_day") or {}
+    seven_day_sonnet = data.get("seven_day_sonnet") or {}
+    extra = data.get("extra_usage") or {}
 
     session_pct = five_hour.get("utilization", 0)
     week_pct = seven_day.get("utilization", 0)

--- a/src/claude_usage/app.py
+++ b/src/claude_usage/app.py
@@ -323,10 +323,10 @@ class ClaudeUsageApp(rumps.App):
         """Update all menu items from API response data."""
         self._last_data = data
 
-        five_hour = data.get("five_hour", {})
-        seven_day = data.get("seven_day", {})
-        seven_day_sonnet = data.get("seven_day_sonnet", {})
-        extra = data.get("extra_usage", {})
+        five_hour = data.get("five_hour") or {}
+        seven_day = data.get("seven_day") or {}
+        seven_day_sonnet = data.get("seven_day_sonnet") or {}
+        extra = data.get("extra_usage") or {}
 
         session_pct = five_hour.get("utilization", 0)
         week_pct = seven_day.get("utilization", 0)


### PR DESCRIPTION
dict.get(key, {}) only uses the default when the key is absent; if the API returns null the value is None. Switch to `or {}` so null values are also treated as empty.