### PR TITLE
Log each unknown usage category once with its field shape

### DIFF
--- a/src/claude_usage/app.py
+++ b/src/claude_usage/app.py
@@ -63,6 +63,7 @@ class ClaudeUsageApp(rumps.App):
         # Dynamic bars for usage categories discovered at runtime.
         # Keyed by API field name → (main_item, reset_item, separator).
         self._dynamic_bars: dict[str, tuple[rumps.MenuItem, rumps.MenuItem, object]] = {}
+        self._logged_unknown_keys: set[str] = set()
 
         # Display mode items
         self._mode_session = rumps.MenuItem(
@@ -334,8 +335,11 @@ class ClaudeUsageApp(rumps.App):
         # Identify unknown usage categories in the response.
         unknown_keys = [k for k in data if k not in self._KNOWN_KEYS]
         for key in unknown_keys:
-            if key not in self._dynamic_bars:
-                logger.info("New usage category in API response: %r", key)
+            if key not in self._logged_unknown_keys:
+                bucket = data.get(key)
+                fields = sorted(bucket.keys()) if isinstance(bucket, dict) else type(bucket).__name__
+                logger.info("New usage category in API response: %r (fields=%s)", key, fields)
+                self._logged_unknown_keys.add(key)
 
         five_hour = data.get("five_hour") or {}
         seven_day = data.get("seven_day") or {}


### PR DESCRIPTION
## Summary
- Dedupe `New usage category in API response` logs by tracking keys in a dedicated `_logged_unknown_keys` set instead of piggy-backing on `_dynamic_bars`. The old check only suppressed re-logging for buckets that actually rendered (i.e. had a `utilization` field); null-valued placeholder buckets re-logged on every 5-minute refresh.
- Include the bucket's field names (or its type if non-dict) in the log line, so it's obvious whether a new category is an inactive `null` placeholder vs. real data that needs a renderer.

## Test plan
- [x] Run `.venv/bin/python -m claude_usage` and confirm each unknown category logs exactly once per process lifetime
- [x] Confirm `null`-valued buckets log as `(fields=NoneType)` and dict-valued buckets log as `(fields=['resets_at', 'utilization', ...])`
- [ ] Leave the widget running across multiple refresh cycles and verify no duplicate "New usage category" lines appear